### PR TITLE
카메라 촬영 기능 구현

### DIFF
--- a/CameraFilterApp.xcodeproj/project.pbxproj
+++ b/CameraFilterApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		C2F1C8172B078F38002F732D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C2F1C8152B078F38002F732D /* LaunchScreen.storyboard */; };
 		ED442E6A2B195B5700A030C6 /* FiltersWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED442E692B195B5700A030C6 /* FiltersWorker.swift */; };
 		ED442E6C2B19628900A030C6 /* FilterMemStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED442E6B2B19628900A030C6 /* FilterMemStore.swift */; };
+		EDB191432B2AA92F00DD1BA9 /* CVPixelBuffer+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB191422B2AA92F00DD1BA9 /* CVPixelBuffer+Extension.swift */; };
 		EDE29D282B1F120F00C73406 /* SliderPropertyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE29D272B1F120F00C73406 /* SliderPropertyView.swift */; };
 		EDE29D2A2B1F652500C73406 /* ColorPickerPropertyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE29D292B1F652500C73406 /* ColorPickerPropertyView.swift */; };
 		EDE29D2C2B1F668F00C73406 /* PropertyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE29D2B2B1F668F00C73406 /* PropertyView.swift */; };
@@ -54,6 +55,7 @@
 		C2F1C8182B078F38002F732D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ED442E692B195B5700A030C6 /* FiltersWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersWorker.swift; sourceTree = "<group>"; };
 		ED442E6B2B19628900A030C6 /* FilterMemStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMemStore.swift; sourceTree = "<group>"; };
+		EDB191422B2AA92F00DD1BA9 /* CVPixelBuffer+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CVPixelBuffer+Extension.swift"; sourceTree = "<group>"; };
 		EDE29D272B1F120F00C73406 /* SliderPropertyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliderPropertyView.swift; sourceTree = "<group>"; };
 		EDE29D292B1F652500C73406 /* ColorPickerPropertyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerPropertyView.swift; sourceTree = "<group>"; };
 		EDE29D2B2B1F668F00C73406 /* PropertyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyView.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				EDEC73752B145DA400595A95 /* CameraPreviewWorker.swift */,
 				EDEC73762B145DA400595A95 /* CameraPreviewRouter.swift */,
 				C284660D2B15EC7C006D4E40 /* FilterCell.swift */,
+				EDB191422B2AA92F00DD1BA9 /* CVPixelBuffer+Extension.swift */,
 			);
 			path = CameraPreview;
 			sourceTree = "<group>";
@@ -295,6 +298,7 @@
 				C24464492B1B1E3400F0B029 /* ListFilterCell.swift in Sources */,
 				C244644D2B1B4E7100F0B029 /* CreateFilterInteractor.swift in Sources */,
 				EDEC737C2B145DA400595A95 /* CameraPreviewRouter.swift in Sources */,
+				EDB191432B2AA92F00DD1BA9 /* CVPixelBuffer+Extension.swift in Sources */,
 				EDE29D282B1F120F00C73406 /* SliderPropertyView.swift in Sources */,
 				EDEC739D2B181E1300595A95 /* ListFiltersModels.swift in Sources */,
 				EDEC73822B14636B00595A95 /* CameraFilter.swift in Sources */,

--- a/CameraFilterApp/Info.plist
+++ b/CameraFilterApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>촬영 및 편집한 이미지를 갤러리에 저장합니다</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/CameraFilterApp/Scenes/CameraPreview/CVPixelBuffer+Extension.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CVPixelBuffer+Extension.swift
@@ -1,0 +1,39 @@
+//
+//  CVPixelBuffer+Extension.swift
+//  CameraFilterApp
+//
+//  Created by siheo on 12/14/23.
+//
+
+import AVFoundation
+
+extension CVPixelBuffer {
+    func copy() -> CVPixelBuffer {
+        precondition(CFGetTypeID(self) == CVPixelBufferGetTypeID(), "copy() cannot be called on a non-CVPixelBuffer")
+        
+        var _copy : CVPixelBuffer?
+        CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            CVPixelBufferGetWidth(self),
+            CVPixelBufferGetHeight(self),
+            CVPixelBufferGetPixelFormatType(self),
+            nil,
+            &_copy)
+        
+        guard let copy = _copy else { fatalError() }
+        
+        CVPixelBufferLockBaseAddress(self, CVPixelBufferLockFlags.readOnly)
+        CVPixelBufferLockBaseAddress(copy, CVPixelBufferLockFlags(rawValue: 0))
+        
+        let copyBaseAddress = CVPixelBufferGetBaseAddress(copy)
+        let currBaseAddress = CVPixelBufferGetBaseAddress(self)
+        
+        memcpy(copyBaseAddress, currBaseAddress, CVPixelBufferGetDataSize(copy))
+        
+        CVPixelBufferUnlockBaseAddress(copy, CVPixelBufferLockFlags(rawValue: 0))
+        CVPixelBufferUnlockBaseAddress(self, CVPixelBufferLockFlags.readOnly)
+        
+        
+        return copy
+    }
+}

--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewInteractor.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewInteractor.swift
@@ -109,7 +109,9 @@ extension CameraPreviewInteractor: AVCaptureVideoDataOutputSampleBufferDelegate 
             return
         }
         
-        let ciImage = CIImage(cvImageBuffer: cvBuffer)
+        let copyBuffer = cvBuffer.copy()
+        
+        let ciImage = CIImage(cvImageBuffer: copyBuffer)
         if let _ = self.appliedFilter {
             guard let filteredImage = applyFilter(inputImage: ciImage) else { return }
             

--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewModels.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewModels.swift
@@ -22,6 +22,15 @@ enum CameraPreview
         var filterName: String
     }
     
+    enum TakePhoto {
+        struct Request {
+        }
+        struct Response {
+        }
+        struct ViewModel {
+        }
+    }
+    
     enum StartSession {
         struct Request {
         }

--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewPresenter.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewPresenter.swift
@@ -16,6 +16,7 @@ protocol CameraPreviewPresentationLogic
 {
     func presentAllFilters(response: CameraPreview.FetchFilters.Response)
     func presentFrameImage(response: CameraPreview.DrawFrameImage.Response)
+    func presentTakePhotoCompletion(response: CameraPreview.TakePhoto.Response)
 }
 
 class CameraPreviewPresenter: CameraPreviewPresentationLogic
@@ -47,5 +48,10 @@ class CameraPreviewPresenter: CameraPreviewPresentationLogic
         
         let viewModel = CameraPreview.DrawFrameImage.ViewModel(frameImage: frameImage, commandBuffer: commandBuffer)
         viewController?.displayFrameImage(viewModel: viewModel)
+    }
+    
+    func presentTakePhotoCompletion(response: CameraPreview.TakePhoto.Response) {
+        let viewModel = CameraPreview.TakePhoto.ViewModel()
+        self.viewController?.displayTakePhotoCopmletion(viewModel: viewModel)
     }
 }

--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewViewController.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewViewController.swift
@@ -17,6 +17,7 @@ protocol CameraPreviewDisplayLogic: AnyObject
 {
     func displayFilterNames(viewModel: CameraPreview.FetchFilters.ViewModel)
     func displayFrameImage(viewModel: CameraPreview.DrawFrameImage.ViewModel)
+    func displayTakePhotoCopmletion(viewModel: CameraPreview.TakePhoto.ViewModel)
 }
 
 class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
@@ -253,7 +254,15 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
     }
     
     @objc private func shotButtonTapped(_ button: UIButton) {
-        print(#function)
+        UIView.animate(withDuration: 0.1, delay: 0.0) {
+            self.previewMTKView.alpha = 0.5
+        }
+        UIView.animate(withDuration: 0.1, delay: 0.1) {
+            self.previewMTKView.alpha = 1.0
+        }
+        self.shotButton.isEnabled = false
+        let request = CameraPreview.TakePhoto.Request()
+        self.interactor?.takePhoto(request)
     }
     
     @objc private func galleryButtonTapped(_ button: UIButton) {
@@ -276,6 +285,12 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
         self.currentBuffer = viewModel.commandBuffer
         
         self.previewMTKView.draw()
+    }
+    
+    func displayTakePhotoCopmletion(viewModel: CameraPreview.TakePhoto.ViewModel) {
+        DispatchQueue.main.async {
+            self.shotButton.isEnabled = true
+        }
     }
 }
 


### PR DESCRIPTION
# What is this PR?
무음으로 사진을 촬영하는 기능을 구현했습니다
여러 필터를 적용시 프리뷰화면이 멈추는 문제를 수정했습니다
# Changes
촬영 버튼 터치시 프리뷰 화면에 렌더링 되는 이미지 버퍼를 UIImage로 변환하여 갤러리에 저장합니다
사용자가 촬영이 진행되었음을 알 수 있도록 프리뷰화면의 alpha 값을 animation 처리했습니다

기존 버그였던 여러 필터 적용시 프리뷰 화면이 멈추는 문제를
sampleBuffer에 strong reference가 걸려 pool에서 해제되지 않아 pool이 가득차서 프레임이 드랍되는 것으로 원인을 확인하여
sampleBuffer를 copy하여 사용하는 것으로 변경하였습니다
# Screenshots
- 사진 촬영

https://github.com/shintwelv/SimpleCameraFilterApp/assets/74942977/8be006d3-93cb-4785-be00-6b593b03ecd4

- 촬영된 이미지 확인

https://github.com/shintwelv/SimpleCameraFilterApp/assets/74942977/209ad84f-45f3-4897-a9fd-b32b9832e0b9

- 프리뷰 프리징 현상 수정

https://github.com/shintwelv/SimpleCameraFilterApp/assets/74942977/4ea0b8ae-bcbe-4cb9-ba0c-448b3a9e5c46


