### PR TITLE
카메라 프리뷰 필터 목록 UI 변경

### DIFF
--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewModels.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewModels.swift
@@ -67,6 +67,7 @@ enum CameraPreview
     struct FilterInfo {
         var filterId: UUID
         var filterName: String
+        var filterAppliedImage: UIImage
     }
     
     enum TakePhoto {

--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewPresenter.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewPresenter.swift
@@ -58,18 +58,23 @@ class CameraPreviewPresenter: CameraPreviewPresentationLogic
         }
     }
     
+    private let baseImage: UIImage = UIImage(named: "lena_color")!
+    
     func presentAllFilters(response: CameraPreview.FetchFilters.Response) {
         let filters = response.filters
         
-        var filterNames:[String] = filters.map { $0.displayName }
-        filterNames.insert("원본", at: 0)
+        var filterInfos:[CameraPreview.FilterInfo] = []
+        filterInfos.append(CameraPreview.FilterInfo(filterId: UUID(), filterName: "원본", filterAppliedImage: self.baseImage))
         
-        var filterInfos = filters.map {
-            return CameraPreview.FilterInfo(filterId: $0.filterId, filterName: $0.displayName)
-        }
-        filterInfos.insert(
-            CameraPreview.FilterInfo(filterId: UUID(), filterName: "원본"),
-            at:0)
+        filters.map { filter in
+            let filterId = filter.filterId
+            let filterName = filter.displayName
+            
+            filter.ciFilter.setValue(CIImage(image: self.baseImage), forKey: kCIInputImageKey)
+            let filterAppliedImage = UIImage(ciImage: filter.ciFilter.outputImage!)
+            
+            return CameraPreview.FilterInfo(filterId: filterId, filterName: filterName, filterAppliedImage: filterAppliedImage)
+        }.forEach { filterInfos.append($0) }
         
         let viewModel = CameraPreview.FetchFilters.ViewModel(filterInfos: filterInfos)
         viewController?.displayFilterNames(viewModel: viewModel)

--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewViewController.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewViewController.swift
@@ -159,7 +159,7 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
     private var filterCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.itemSize = CGSize(width: 80, height: 80)
+        layout.itemSize = FilterCell.cellSize
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = true
@@ -328,7 +328,7 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
             self.filterCollectionView.centerYAnchor.constraint(equalTo: self.bottomContentView.centerYAnchor),
             self.filterCollectionView.leadingAnchor.constraint(equalTo: self.bottomContentView.leadingAnchor, constant: 15),
             self.filterCollectionView.trailingAnchor.constraint(equalTo: self.filterToggleButton.leadingAnchor, constant: -15),
-            self.filterCollectionView.heightAnchor.constraint(equalToConstant: 80),
+            self.filterCollectionView.heightAnchor.constraint(equalToConstant: FilterCell.cellSize.height),
         ])
     }
     
@@ -502,7 +502,7 @@ extension CameraPreviewViewController: UICollectionViewDataSource {
         
         let filterInfo = filterInfos[indexPath.row]
         
-        cell.configure(name: filterInfo.filterName)
+        cell.configure(name: filterInfo.filterName, filterAppliedImage: filterInfo.filterAppliedImage)
         return cell
     }
     

--- a/CameraFilterApp/Scenes/CameraPreview/FilterCell.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/FilterCell.swift
@@ -9,7 +9,10 @@ import UIKit
 
 class FilterCell: UICollectionViewCell {
     
-    var nameLabel: UILabel!
+    static let cellSize: CGSize = CGSize(width: 80, height: 100)
+    
+    private var sampleImageView: UIImageView!
+    private var nameLabel: UILabel!
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -24,9 +27,15 @@ class FilterCell: UICollectionViewCell {
     }
     
     private func configureCell() {
+        self.sampleImageView = {
+            let view = UIImageView()
+            view.contentMode = .scaleAspectFit
+            return view
+        }()
+        
         self.nameLabel = {
             let label = UILabel()
-            label.font = .systemFont(ofSize: 18)
+            label.font = .systemFont(ofSize: 12)
             label.textColor = .black
             label.textAlignment = .center
             label.numberOfLines = 1
@@ -34,23 +43,32 @@ class FilterCell: UICollectionViewCell {
             return label
         }()
         
-        self.contentView.layer.borderWidth = 1
-        self.contentView.layer.borderColor = UIColor.black.cgColor
-        
-        self.contentView.addSubview(nameLabel)
+        [
+            self.nameLabel,
+            self.sampleImageView,
+        ].forEach { self.contentView.addSubview($0) }
     }
     
     private func configureAutoLayout() {
-        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        [
+            self.nameLabel,
+            self.sampleImageView,
+        ].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         
         NSLayoutConstraint.activate([
-            nameLabel.widthAnchor.constraint(equalTo: self.contentView.widthAnchor, multiplier: 1.0),
-            nameLabel.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
-            nameLabel.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor)
+            self.sampleImageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+            self.sampleImageView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+            self.sampleImageView.widthAnchor.constraint(equalTo: self.contentView.widthAnchor),
+            self.sampleImageView.heightAnchor.constraint(equalTo: self.sampleImageView.widthAnchor),
+            
+            self.nameLabel.widthAnchor.constraint(equalTo: self.contentView.widthAnchor),
+            self.nameLabel.topAnchor.constraint(equalTo: self.sampleImageView.bottomAnchor, constant: 5),
+            self.nameLabel.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
         ])
     }
     
-    func configure(name: String) {
+    func configure(name: String, filterAppliedImage: UIImage) {
         self.nameLabel.text = name
+        self.sampleImageView.image = filterAppliedImage
     }
 }


### PR DESCRIPTION
# What is this PR for?
카메라 프리뷰 화면에서 필터 목록의 UI를 변경합니다

# Changes
카메라 프리뷰 화면에서 필터 버튼을 터치했을 시 나타나는 필터 셀의 UI를 변경했습니다

<기존>
- 필터 별명

<변경>
- 필터 적용 예시 이미지
- 필터 별명

# Screenshot
![IMG_1044](https://github.com/shintwelv/SimpleCameraFilterApp/assets/74942977/583a5481-6d65-4b82-88ae-70cf44cca1ea)