### PR TITLE
5.5인치 대응 UI 수정

### DIFF
--- a/CameraFilterApp/Scenes/CameraPreview/CameraPreviewViewController.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/CameraPreviewViewController.swift
@@ -127,7 +127,6 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
         let button = UIButton(type: .system)
         button.setImage(UIImage(systemName: "photo"), for: .normal)
         button.backgroundColor = .systemGray6
-        button.layer.cornerRadius = 30
         return button
     }()
     
@@ -135,7 +134,6 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
         let button = UIButton(type: .system)
         button.layer.borderColor = UIColor.systemPurple.cgColor
         button.layer.borderWidth = 5
-        button.layer.cornerRadius = 40
         return button
     }()
     
@@ -143,13 +141,13 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
         let button = UIButton(type: .system)
         button.setImage(UIImage(systemName: "camera.filters"), for: .normal)
         button.backgroundColor = .systemGray6
-        button.layer.cornerRadius = 30
         return button
     }()
     
     private var filterEditButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("편집", for: .normal)
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.tintColor = .systemPurple
         button.titleLabel?.font = .systemFont(ofSize: 18)
         button.isHidden = true
@@ -159,7 +157,6 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
     private var filterCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.itemSize = FilterCell.cellSize
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = true
@@ -206,6 +203,10 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
         interactor?.pauseSession(request)
     }
     
+    override func viewWillLayoutSubviews() {
+        configureCornerRadius()
+    }
+    
     private func configureUI() {
         self.view.backgroundColor = .white
         
@@ -246,6 +247,17 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
         self.filterCollectionView.dataSource = self
         
         self.filterCollectionView.register(FilterCell.self, forCellWithReuseIdentifier: "filterCell")
+    }
+    
+    private func configureCornerRadius() {
+        [
+            self.galleryButton,
+            self.filterToggleButton,
+            self.shotButton
+        ].forEach {
+            let frame = $0.frame
+            $0.layer.cornerRadius = frame.width / 2
+        }
     }
     
     private func configureAutoLayout() {
@@ -306,30 +318,45 @@ class CameraPreviewViewController: UIViewController, CameraPreviewDisplayLogic
             self.bottomContentView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             
             self.galleryButton.centerYAnchor.constraint(equalTo: self.bottomContentView.centerYAnchor),
-            self.galleryButton.widthAnchor.constraint(equalToConstant: 60),
+            self.galleryButton.heightAnchor.constraint(lessThanOrEqualToConstant: 60),
             self.galleryButton.heightAnchor.constraint(equalTo: self.galleryButton.widthAnchor),
             self.galleryButton.leadingAnchor.constraint(equalTo: self.bottomContentView.leadingAnchor, constant: 15),
             
             self.shotButton.centerYAnchor.constraint(equalTo: self.bottomContentView.centerYAnchor),
-            self.shotButton.widthAnchor.constraint(equalToConstant: 80),
-            self.shotButton.heightAnchor.constraint(equalTo: self.shotButton.widthAnchor),
+            self.shotButton.heightAnchor.constraint(lessThanOrEqualToConstant: 100),
+            self.shotButton.widthAnchor.constraint(equalTo: self.shotButton.heightAnchor),
             self.shotButton.centerXAnchor.constraint(equalTo: self.bottomContentView.centerXAnchor),
             
             self.filterToggleButton.centerYAnchor.constraint(equalTo: self.bottomContentView.centerYAnchor),
-            self.filterToggleButton.widthAnchor.constraint(equalToConstant: 60),
-            self.filterToggleButton.heightAnchor.constraint(equalTo: self.filterToggleButton.widthAnchor),
+            self.filterToggleButton.heightAnchor.constraint(lessThanOrEqualToConstant: 60),
+            self.filterToggleButton.widthAnchor.constraint(equalTo: self.filterToggleButton.heightAnchor),
             self.filterToggleButton.trailingAnchor.constraint(equalTo: self.bottomContentView.trailingAnchor, constant: -15),
             
-            self.filterEditButton.widthAnchor.constraint(equalToConstant: 60),
-            self.filterEditButton.heightAnchor.constraint(equalToConstant: 30),
-            self.filterEditButton.bottomAnchor.constraint(equalTo: self.filterToggleButton.topAnchor, constant: -10),
-            self.filterEditButton.trailingAnchor.constraint(equalTo: self.filterToggleButton.trailingAnchor),
+            self.filterEditButton.widthAnchor.constraint(equalTo: self.filterToggleButton.widthAnchor),
+            self.filterEditButton.centerXAnchor.constraint(equalTo: self.filterToggleButton.centerXAnchor),
+            self.filterEditButton.topAnchor.constraint(equalTo: self.bottomContentView.topAnchor),
+            self.filterEditButton.bottomAnchor.constraint(equalTo: self.filterToggleButton.topAnchor, constant: -5),
             
             self.filterCollectionView.centerYAnchor.constraint(equalTo: self.bottomContentView.centerYAnchor),
-            self.filterCollectionView.leadingAnchor.constraint(equalTo: self.bottomContentView.leadingAnchor, constant: 15),
-            self.filterCollectionView.trailingAnchor.constraint(equalTo: self.filterToggleButton.leadingAnchor, constant: -15),
-            self.filterCollectionView.heightAnchor.constraint(equalToConstant: FilterCell.cellSize.height),
+            self.filterCollectionView.heightAnchor.constraint(lessThanOrEqualToConstant: 120),
+            self.filterCollectionView.leadingAnchor.constraint(equalTo: self.bottomContentView.leadingAnchor, constant: 5),
+            self.filterCollectionView.trailingAnchor.constraint(equalTo: self.filterToggleButton.leadingAnchor, constant: -5),
         ])
+        
+        [
+            (15, self.shotButton),
+            (5, self.filterCollectionView),
+            (30, self.galleryButton),
+            (30, self.filterToggleButton),
+        ].map { (padding, view) in
+            [
+                view.topAnchor.constraint(equalTo: self.bottomContentView.topAnchor, constant: padding),
+                view.bottomAnchor.constraint(equalTo: self.bottomContentView.bottomAnchor, constant: -padding),
+            ]
+        }.flatMap{$0}.forEach {
+            $0.priority = .defaultHigh
+            $0.isActive = true
+        }
     }
     
     func configureMTKView() {
@@ -499,6 +526,18 @@ extension CameraPreviewViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return self.filterInfos.count
+    }
+}
+
+extension CameraPreviewViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        let collectionViewFrame = collectionView.frame
+
+        let cellHeight = collectionViewFrame.height - 15
+        let cellWidth = cellHeight - 20
+
+        return CGSize(width: cellWidth, height: cellHeight)
     }
 }
 

--- a/CameraFilterApp/Scenes/CameraPreview/FilterCell.swift
+++ b/CameraFilterApp/Scenes/CameraPreview/FilterCell.swift
@@ -9,8 +9,6 @@ import UIKit
 
 class FilterCell: UICollectionViewCell {
     
-    static let cellSize: CGSize = CGSize(width: 80, height: 100)
-    
     private var sampleImageView: UIImageView!
     private var nameLabel: UILabel!
 
@@ -56,14 +54,15 @@ class FilterCell: UICollectionViewCell {
         ].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         
         NSLayoutConstraint.activate([
+            self.sampleImageView.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
             self.sampleImageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
-            self.sampleImageView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
-            self.sampleImageView.widthAnchor.constraint(equalTo: self.contentView.widthAnchor),
-            self.sampleImageView.heightAnchor.constraint(equalTo: self.sampleImageView.widthAnchor),
+            self.sampleImageView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -20),
+            self.sampleImageView.widthAnchor.constraint(equalTo: self.sampleImageView.heightAnchor),
             
-            self.nameLabel.widthAnchor.constraint(equalTo: self.contentView.widthAnchor),
+            self.nameLabel.widthAnchor.constraint(equalTo: self.sampleImageView.widthAnchor),
             self.nameLabel.topAnchor.constraint(equalTo: self.sampleImageView.bottomAnchor, constant: 5),
-            self.nameLabel.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
+            self.nameLabel.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+            self.nameLabel.centerXAnchor.constraint(equalTo: self.sampleImageView.centerXAnchor),
         ])
     }
     


### PR DESCRIPTION
# What is this PR for?

5.5 인치 기기에서 UI가 망가지지 않도록 수정했습니다

# Changes

AutoLayout의 lessThanEqualTo, priority 를 활용하여 width, height의 최댓값을 설정했습니다
5.5인치 기기에서는 bottomContenView의 높이에 일정 padding을 적용한 width, height로 설정되며,
그보다 큰 기기에서는 lessThanEqualTo에 설정된 width, height로 설정됩니다.

# Screenshot

- 5.5 인치 기기

![smallScreen](https://github.com/shintwelv/SimpleCameraFilterApp/assets/74942977/c1f92d37-c378-44a7-aea6-9f6242385e83)

- 더 큰 기기

![largeScreen](https://github.com/shintwelv/SimpleCameraFilterApp/assets/74942977/b9a3b087-ba38-4808-8d96-c033cd745344)
